### PR TITLE
Add an alternative action aware required param

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -47,11 +47,7 @@ module Apipie
       @parent = @options[:parent]
       @metadata = @options[:meta]
 
-      @required = if @options.has_key? :required
-        @options[:required]
-      else
-        Apipie.configuration.required_by_default?
-      end
+      @required = is_required?
 
       @show = if @options.has_key? :show
         @options[:show]
@@ -208,6 +204,18 @@ module Apipie
 
     def preformat_text(text)
       concern_subst(Apipie.markup_to_html(text || ''))
+    end
+
+    def is_required?
+      if @options.has_key?(:required)
+        if (@options[:required] == true) || (@options[:required] == false)
+          @options[:required]
+        else
+          Array(@options[:required]).include?(@method_description.method.to_sym)
+        end
+      else
+        Apipie.configuration.required_by_default?
+      end
     end
 
   end

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -172,6 +172,33 @@ describe Apipie::ParamDescription do
 
   end
 
+  describe "required params on given actions" do
+    let(:method_desc) do
+      Apipie::MethodDescription.new(:create, resource_desc, dsl_data)
+    end
+
+    context "when the param is required for current action" do
+      it "should set param as required" do
+        param = Apipie::ParamDescription.new(method_desc, :required, String, 'description','required' => :create)
+        param.required.should be_true
+      end
+    end
+
+    context "when the param is required for multiple actions" do
+      it "should set param as required if it match current action" do
+        param = Apipie::ParamDescription.new(method_desc, :required, String, 'description','required' => [:update, :create])
+        param.required.should be_true
+      end
+    end
+
+    context "when the param is not required for current action" do
+      it "should set param as not required" do
+        param = Apipie::ParamDescription.new(method_desc, :required, String, 'description','required' => :update)
+        param.required.should be_false
+      end
+    end
+  end
+
   describe "required params in action aware validator" do
 
     subject { method_description.params[:user].validator.params_ordered }


### PR DESCRIPTION
Feature
======
Make a param required only for specific actions

Examples
========
**Make a param required for all actions**

```ruby
param :name, String, required true
```

**Make a param required only for update action**
```ruby
param :name, String, required :update
```

**Make a param required only for update and create actions**

```ruby
param :name, String, required [:update, :create ]
```

Notes
=====
This feature is overridden by action aware param if specified 

